### PR TITLE
Add R16 as a valid OTP release required.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
         {ibrowse, "", {git, "git://github.com/cmullaparthi/ibrowse.git", {branch, "master"}}}
        ]}.
 
-{require_otp_vsn, "R14|R15"}.
+{require_otp_vsn, "R14|R15|R16"}.
 
 {erl_opts, [
             fail_on_warning,


### PR DESCRIPTION
Avoid rebar error when using R16.
