### PR TITLE
Include an (arbitrary) version number

### DIFF
--- a/src/ddb.app.src
+++ b/src/ddb.app.src
@@ -4,7 +4,7 @@
 {application, ddb,
  [
   {description, "AWS DynamoDB client"},
-  {vsn, git},
+  {vsn, "0.1.0"},
   {registered, [ddb_sup]},
   {applications, [
                   kernel,


### PR DESCRIPTION
Without a version number in .app.src, rebar will not compile the application unless it is also a Git repository. This means that packaged (.tar.gz) code will fail to build with rebar. Including a version number fixes the problem. 0.1.0 seems like a reasonable start.
