### PR TITLE
switch to ibrowse tag v4.0.2 - master is broken

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {deps, [
         {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}},
-        {ibrowse, "", {git, "git://github.com/cmullaparthi/ibrowse.git", {branch, "master"}}}
+        {ibrowse, "", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
        ]}.
 
 {require_otp_vsn, "R14|R15|R16"}.


### PR DESCRIPTION
ibrowse currently has an issue in master, crashing gen_server after each (GET) request. Tag v4.0.2 does not have this issue
