### PR TITLE
Allow compiling on OTP 17.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
         {ibrowse, "", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
        ]}.
 
-{require_otp_vsn, "R14|R15|R16"}.
+{require_otp_vsn, "R14|R15|R16|17"}.
 
 {erl_opts, [
             fail_on_warning,


### PR DESCRIPTION
This is a simple patch to update rebar.config to allow compiling on Erlang 17.0 just released. As the versioning scheme has changed with the latest version, matching on `R17` wouldn't work like it does for the previous versions. Instead, we just match on `17`.
