### PR TITLE
Set dependency on 'v2.6.1' tag of the 'jsx' project

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
 {lib_dirs, ["deps"]}.
 
 {deps, [
-        {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {branch, "master"}}},
+        {jsx, ".*", {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.6.1"}}},
         {ibrowse, "", {git, "git://github.com/cmullaparthi/ibrowse.git", {tag, "v4.0.2"}}}
        ]}.
 


### PR DESCRIPTION
This is just to have a clearer dependency graph so that it does not depend on a 'master' branch that could possibly move forward. 
